### PR TITLE
WWS: UserFile now only read on startup

### DIFF
--- a/java/WoolWebService/src/main/java/eu/woolplatform/webservice/UserFile.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/webservice/UserFile.java
@@ -51,7 +51,7 @@ public class UserFile {
 		return null;
 	}
 
-	private static List<UserCredentials> read() throws ParseException,
+	public static List<UserCredentials> read() throws ParseException,
 			IOException {
 		Configuration config = Configuration.getInstance();
 		File dataDir = new File(config.get(Configuration.DATA_DIR));

--- a/java/WoolWebService/src/main/java/eu/woolplatform/webservice/controller/AuthController.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/webservice/controller/AuthController.java
@@ -31,6 +31,7 @@ import eu.woolplatform.webservice.exception.*;
 import io.swagger.annotations.Api;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
@@ -45,6 +46,9 @@ import java.util.Map;
 @RestController
 @RequestMapping("/v{version}/auth")
 public class AuthController {
+	@Autowired
+	Application application;
+
 	private static final Object AUTH_LOCK = new Object();
 
 	@RequestMapping(value="/login", method= RequestMethod.POST, consumes={
@@ -60,7 +64,7 @@ public class AuthController {
 		synchronized (AUTH_LOCK) {
 			return QueryRunner.runQuery(
 					(version, user) -> doLogin(request, loginParams),
-					versionName, null, response, "");
+					versionName, null, response, "", application);
 		}
 	}
 

--- a/java/WoolWebService/src/main/java/eu/woolplatform/webservice/controller/DataController.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/webservice/controller/DataController.java
@@ -67,12 +67,12 @@ public class DataController {
 			logger.info("Get /variables?names=" + names);
 			return QueryRunner.runQuery(
 				(version, user) -> doGetVariables(user, names),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		} else {
 			logger.info("Get /variables?names=" + names+"&woolUserId="+woolUserId);
 			return QueryRunner.runQuery(
 				(version, user) -> doGetVariables(woolUserId, names),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		}
 	}
 
@@ -126,12 +126,12 @@ public class DataController {
 			logger.info("Post /variable?name=" + name + "&value=" + value);
 			QueryRunner.runQuery((version, user) ->
 				doSetVariable(request, user, name, value),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		} else {
 			logger.info("Post /variable?name=" + name + "&value=" + value + "&woolUserId=" + woolUserId);
 			QueryRunner.runQuery((version, user) ->
 				doSetVariable(request, woolUserId, name, value),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		}
 	}
 
@@ -184,11 +184,11 @@ public class DataController {
 		if(woolUserId.equals("")) {
 			logger.info("Post /variables");
 			QueryRunner.runQuery((version, user) -> doSetVariables(request, user),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		} else {
 			logger.info("Post /variables?woolUserId="+woolUserId);
 			QueryRunner.runQuery((version, user) -> doSetVariables(request, woolUserId),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		}
 	}
 

--- a/java/WoolWebService/src/main/java/eu/woolplatform/webservice/controller/DialogueController.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/webservice/controller/DialogueController.java
@@ -97,14 +97,14 @@ public class DialogueController {
 			return QueryRunner.runQuery(
 					(version, user) -> doStartDialogue(user, dialogueName,
 							language, time, timezone),
-					versionName, request, response, woolUserId);
+					versionName, request, response, woolUserId, application);
 		} else {
 			logger.info("Post /start-dialogue?dialogueName=" + dialogueName +
 					"&language=" + language+"&userId="+woolUserId);
 			return QueryRunner.runQuery(
 					(version, user) -> doStartDialogue(woolUserId, dialogueName,
 							language, time, timezone),
-					versionName, request, response, woolUserId);
+					versionName, request, response, woolUserId, application);
 		}
 	}
 
@@ -170,14 +170,14 @@ public class DialogueController {
 				(version, user) -> doProgressDialogue(user, request,
 						loggedDialogueId, loggedInteractionIndex, replyId,
 						time, timezone),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		} else {
 			logger.info("POST /progress-dialogue?replyId=" + replyId+"&woolUserId="+woolUserId);
 			return QueryRunner.runQuery(
 				(version, user) -> doProgressDialogue(woolUserId, request,
 					loggedDialogueId, loggedInteractionIndex, replyId,
 					time, timezone),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		}
 	}
 
@@ -243,13 +243,13 @@ public class DialogueController {
 			return QueryRunner.runQuery(
 				(version, user) -> doBackDialogue(user, loggedDialogueId,
 						loggedInteractionIndex, time, timezone),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		} else {
 			logger.info("POST /back-dialogue?woolUserId="+woolUserId);
 			return QueryRunner.runQuery(
 				(version, user) -> doBackDialogue(woolUserId, loggedDialogueId,
 						loggedInteractionIndex, time, timezone),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		}
 	}
 
@@ -290,13 +290,13 @@ public class DialogueController {
 			return QueryRunner.runQuery(
 				(version, user) -> doGetCurrentDialogue(user, dialogueName,
 						time, timezone),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		} else {
 			logger.info("Get /current-dialogue?dialogueName=" + dialogueName+"&woolUserId="+woolUserId);
 			return QueryRunner.runQuery(
 				(version, user) -> doGetCurrentDialogue(woolUserId, dialogueName,
 						time, timezone),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		}
 	}
 
@@ -346,11 +346,11 @@ public class DialogueController {
 		if(woolUserId.equals("")) {
 			logger.info("POST /cancel-dialogue");
 			QueryRunner.runQuery((version, user) -> doCancelDialogue(user, loggedDialogueId),
-				versionName, request, response, woolUserId);
+				versionName, request, response, woolUserId, application);
 		} else {
 			logger.info("POST /cancel-dialogue?woolUserId="+woolUserId);
 			QueryRunner.runQuery((version, user) -> doCancelDialogue(woolUserId, loggedDialogueId),
-					versionName, request, response, woolUserId);
+					versionName, request, response, woolUserId, application);
 		}
 	}
 

--- a/java/WoolWebService/src/main/java/eu/woolplatform/webservice/execution/UserServiceManager.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/webservice/execution/UserServiceManager.java
@@ -24,6 +24,8 @@ package eu.woolplatform.webservice.execution;
 import eu.woolplatform.utils.AppComponents;
 import eu.woolplatform.utils.exception.DatabaseException;
 import eu.woolplatform.utils.exception.ParseException;
+import eu.woolplatform.webservice.UserCredentials;
+import eu.woolplatform.webservice.UserFile;
 import eu.woolplatform.webservice.exception.HttpFieldError;
 import eu.woolplatform.wool.exception.WoolException;
 import eu.woolplatform.wool.i18n.WoolTranslationContext;
@@ -59,6 +61,7 @@ public class UserServiceManager {
 	private Logger logger = AppComponents.getLogger(getClass().getSimpleName());
 	private WoolProject woolProject;
 	private List<UserService> activeUserServices = new ArrayList<>();
+	private List<UserCredentials> userCredentials;
 
 	// ----- Constructors
 	
@@ -96,6 +99,17 @@ public class UserServiceManager {
 			throw new RuntimeException("Failed to load all dialogues.");
 		woolProject = readResult.getProject();
 		appConfig.setWoolProject(woolProject);
+
+		// Read all UserCredentials from users.xml
+		try {
+			userCredentials = UserFile.read();
+		} catch (
+				ParseException e) {
+			throw new RuntimeException(e);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
 		long endMS = System.currentTimeMillis();
 		long procTime = endMS - startMS;
 		logger.info("UserServiceManager initialized in "+procTime+"ms.");
@@ -105,6 +119,27 @@ public class UserServiceManager {
 	
 	public List<WoolDialogueDescription> getDialogueDescriptions() {
 		return new ArrayList<>(woolProject.getDialogues().keySet());
+	}
+
+	/**
+	 * Returns the list of {@link UserCredentials} available for this {@link UserServiceManager}.
+	 * @return the list of {@link UserCredentials} available for this {@link UserServiceManager}.
+	 */
+	public List<UserCredentials> getUserCredentials() {
+		return userCredentials;
+	}
+
+	/**
+	 * Returns the {@link UserCredentials} object associated with the given {@code username}, or {@code null}
+	 * if no such user is known.
+	 * @param username the username of the user to look for.
+	 * @return the {@link UserCredentials} object or {@code null}.
+	 */
+	public UserCredentials getUserCredentialsForUsername(String username) {
+		for(UserCredentials uc : userCredentials) {
+			if(uc.getUsername().equals(username)) return uc;
+		}
+		return null;
 	}
 	
 	// ---------- Service Management:


### PR DESCRIPTION
This fixes an issue in WOOL Web Service where the user.xml file was being read for every call to a dialogue end-point... twice... Now the userfile is read on service startup and never again. So, adding new users to the user.xml file while the service is running will no longer work.