### PR TITLE
Update to timeZone handling in WWS

### DIFF
--- a/java/WoolExternalVariableServiceDummy/src/main/java/eu/woolplatform/web/varservice/controller/VariablesController.java
+++ b/java/WoolExternalVariableServiceDummy/src/main/java/eu/woolplatform/web/varservice/controller/VariablesController.java
@@ -42,6 +42,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -70,7 +71,10 @@ public class VariablesController {
 					"Variables in order to verify that you have the latest values for all variables. In return you" +
 					"will receive a list - which is a subset of the list you provided - that contains all WOOL " +
 					"Variables for which an updated value is available. You are basically asking: 'Hey, I have this " +
-					"list of WOOL Variables for this user, is this up-to-date?'.")
+					"list of WOOL Variables for this user, is this up-to-date?'." +
+					"<br/><br/>In this dummy implementation, for every variable that you include in the request list" +
+					" there is a 50% chance that it will be returned in the response list, with the same value as provided" +
+					" in the request, and the lastUpdated time set to the current UTC time in epoch seconds.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Successful operation",
 					content = @Content(array = @ArraySchema(schema = @Schema(implementation = WoolVariableParam.class)))) })
@@ -111,10 +115,9 @@ public class VariablesController {
 	 * This method performs the "dummy" updating of the requested list of WOOL Variables. For a real-world
 	 * implementation you should replace this method and make sure it does something useful.
 	 *
-	 * In this dummy implementation, the method does the following. There is a 50% chance that this
-	 * method will return an empty list (i.e. no variables need to be updated). The other 50% of the
-	 * time, this method will return the given input list of parameters, with each of the {@code value}s reversed,
-	 * and the {@code lastUpdated} set to the current time.
+	 * In this dummy implementation, the method does the following. For every WOOL Variable for which an
+	 * update is requested, there is a 50% chance that this variable will be included in the result set with
+	 * a lastUpdated timestamp set to the current UTC time in Epoch seconds.
 	 *
 	 * @param userId the {@code String} identifier of the user who's variable updates are requested.
 	 * @param params the {@code List} of {@link WoolVariableParam}s for which it should be verified if an update is needed.
@@ -127,16 +130,16 @@ public class VariablesController {
 
 		Random random = new Random();
 
-		if(random.nextBoolean()) { // With 50% chance, reverse all parameter values
+		Instant now = Instant.now();
 
-			for (WoolVariableParam param : params) {
+		for (WoolVariableParam param : params) {
+			if(random.nextBoolean()) { // With 50% chance, return the variable as if it has been updated
 				WoolVariableParam newParam = new WoolVariableParam(
 						param.getName(),
-						new StringBuilder(param.getValue()).reverse().toString(),
-						System.currentTimeMillis());
+						param.getValue(),
+						now.getEpochSecond());
 				result.add(newParam);
 			}
-
 		}
 
 		return result;
@@ -147,7 +150,9 @@ public class VariablesController {
 	@Operation(summary = "Inform that the given list of WOOL Variables have been updated",
 			description = "With this end-point you can inform this WOOL External Variable Service " +
 					"that a list of WOOL Variables have been updated (e.g. during dialogue execution) " +
-					"for a particular user.")
+					"for a particular user." +
+					"<br/><br/>In this dummy implementation, the service will do nothing with your provided" +
+					" variables, and the end-point will simply return a status 200 (OK).")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Successful operation") })
 	@RequestMapping(value="/notify-updated/{userId}", method= RequestMethod.POST, consumes={

--- a/java/WoolExternalVariableServiceDummy/src/main/java/eu/woolplatform/web/varservice/controller/model/WoolVariableParam.java
+++ b/java/WoolExternalVariableServiceDummy/src/main/java/eu/woolplatform/web/varservice/controller/model/WoolVariableParam.java
@@ -33,7 +33,7 @@ public class WoolVariableParam {
 			example = "some value", required = true)
 	private String value;
 
-	@Schema(description = "UNIX Timestamp indicating when this value was last updated",
+	@Schema(description = "UTC Timestamp indicating when this value was last updated",
 			example = "1655985982", required = true)
 	private Long lastUpdated;
 

--- a/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/UserService.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/UserService.java
@@ -61,6 +61,7 @@ import java.util.*;
 public class UserService {
 
 	public String userId;
+	private String timeZone;
 	public UserServiceManager userServiceManager;
 	public WoolVariableStore variableStore;
 
@@ -124,6 +125,22 @@ public class UserService {
 	 */
 	public String getUserId() {
 		return userId;
+	}
+
+	/**
+	 * Returns the latest known timezone for this user as one of {@code TimeZone.getAvailableIDs()} (IANA Codes).
+	 * @return the latest known timezone for this user as one of {@code TimeZone.getAvailableIDs()} (IANA Codes).
+	 */
+	public String getTimeZone() {
+		return timeZone;
+	}
+
+	/**
+	 * Sets the latest known timezone for this user as one of {@code TimeZone.getAvailableIDs()} (IANA Codes).
+	 * @param timeZone the latest known timezone for this user as one of {@code TimeZone.getAvailableIDs()} (IANA Codes).
+	 */
+	public void setTimeZone(String timeZone) {
+		this.timeZone = timeZone;
 	}
 
 	public WoolTranslationContext getTranslationContext() {

--- a/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/UserServiceManager.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/UserServiceManager.java
@@ -219,36 +219,34 @@ public class UserServiceManager {
 		return result;
 	}
 
-	public static DateTime parseTimeParameters(String time, String timezone,
-			List<HttpFieldError> errors) {
+	/**
+	 *
+	 * @param timeZone one of {@code DateTimeZone.getAvailableIDs()} (e.g. "Europe/Lisbon").
+	 * @param errors
+	 * @return
+	 */
+	public static DateTime parseTimeParameters(String timeZone, List<HttpFieldError> errors) {
 		DateTimeZone parsedTimezone = null;
-		LocalDateTime parsedTime = null;
 		int errorsStart = errors.size();
-		if (timezone == null || timezone.length() == 0) {
+
+		if (timeZone == null || timeZone.length() == 0) {
 			parsedTimezone = DateTimeZone.getDefault();
 		} else {
 			try {
-				parsedTimezone = DateTimeZone.forID(timezone);
+				parsedTimezone = DateTimeZone.forID(timeZone);
 			} catch (IllegalArgumentException ex) {
-				errors.add(new HttpFieldError("timezone",
-						"Invalid value for field \"timezone\": " + timezone));
+				errors.add(new HttpFieldError("timeZone",
+						"Invalid value for field \"timeZone\": " + timeZone));
 			}
 		}
-		if (time == null || time.length() == 0) {
-			parsedTime = new LocalDateTime(parsedTimezone);
-		} else {
-			DateTimeFormatter parser = DateTimeFormat.forPattern(
-					"yyyy-MM-dd'T'HH:mm:ss.SSS");
-			try {
-				parsedTime = parser.parseLocalDateTime(time);
-			} catch (IllegalArgumentException ex) {
-				errors.add(errorsStart, new HttpFieldError("time",
-						"Invalid value for field \"time\": " + time));
-			}
-		}
-		if (!errors.isEmpty())
+
+		LocalDateTime parsedTime = new LocalDateTime(parsedTimezone);
+
+		if (!errors.isEmpty()) {
 			return null;
-		return parsedTime.toDateTime(parsedTimezone);
+		} else {
+			return parsedTime.toDateTime(parsedTimezone);
+		}
 	}
 
 	public String getExternalVariableServiceAPIToken() {


### PR DESCRIPTION
timeZone parameter is now mandatory for start-dialogue and current-dialogue end-points in WWS. "time" parameters have been removed everywhere, as well as "timeZone" on those end-points where it is not mandatory.