### PR TITLE
WWS start end-point now accepts 'sessionId'

### DIFF
--- a/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/DialogueExecutor.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/DialogueExecutor.java
@@ -68,21 +68,22 @@ public class DialogueExecutor {
 	// -------------------------------------------------------
 
 	/**
-	 * Starts the dialogue for the specified dialogue definition. It starts at
-	 * the start node.
+	 * Starts the dialogue for the specified dialogue definition at the default start node
+	 * ('Start').
 	 *
-	 * @param dialogueDescription the dialogue description
-	 * @param dialogueDefinition the dialogue definition
-	 * @return the start node
-	 * @throws DatabaseException if a database error occurs
-	 * @throws IOException if a communication error occurs
-	 * @throws WoolException if the request is invalid
+	 * @param dialogueDescription the dialogue description.
+	 * @param dialogueDefinition the dialogue definition.
+	 * @param sessionId an optional externally provided id to be added to the logs (or
+	 *                    {@code null}).
+	 * @return the start node.
+	 * @throws DatabaseException if a database error occurs.
+	 * @throws IOException if a communication error occurs.
+	 * @throws WoolException if the request is invalid.
 	 */
-	public ExecuteNodeResult startDialogue(
-			WoolDialogueDescription dialogueDescription,
-			WoolDialogue dialogueDefinition)
-			throws DatabaseException, IOException, WoolException {
-		return startDialogue(dialogueDescription, dialogueDefinition, null);
+	public ExecuteNodeResult startDialogue(WoolDialogueDescription dialogueDescription,
+			WoolDialogue dialogueDefinition, String sessionId)
+			throws IOException, DatabaseException, WoolException {
+		return startDialogue(dialogueDescription, dialogueDefinition, null, sessionId);
 	}
 
 	/**
@@ -90,17 +91,18 @@ public class DialogueExecutor {
 	 * a node ID, it will start at that node. Otherwise, it starts at the start
 	 * node.
 	 *
-	 * @param dialogueDescription the dialogue description
-	 * @param dialogueDefinition the dialogue definition
-	 * @param nodeId the node ID or null
-	 * @return the start node or specified node
-	 * @throws DatabaseException if a database error occurs
-	 * @throws IOException if a communication error occurs
-	 * @throws WoolException if the request is invalid
+	 * @param dialogueDescription the dialogue description.
+	 * @param dialogueDefinition the dialogue definition.
+	 * @param nodeId the node ID or {@code null}.
+	 * @param sessionId an optional externally provided id to be added to the logs (or
+	 *                    {@code null}).
+	 * @return the start node or specified node.
+	 * @throws DatabaseException if a database error occurs.
+	 * @throws IOException if a communication error occurs.
+	 * @throws WoolException if the request is invalid.
 	 */
-	public ExecuteNodeResult startDialogue(
-			WoolDialogueDescription dialogueDescription,
-			WoolDialogue dialogueDefinition, String nodeId)
+	public ExecuteNodeResult startDialogue(WoolDialogueDescription dialogueDescription,
+			WoolDialogue dialogueDefinition, String nodeId, String sessionId)
 			throws DatabaseException, IOException, WoolException {
 		ActiveWoolDialogue dialogue = new ActiveWoolDialogue(
 				dialogueDescription, dialogueDefinition);
@@ -124,7 +126,7 @@ public class DialogueExecutor {
 					e.getMessage(), e);
 		}
 		LoggedDialogue loggedDialogue =
-				new LoggedDialogue(userService.getWoolUser().getId(), eventTime);
+				new LoggedDialogue(userService.getWoolUser().getId(), eventTime, sessionId);
 		loggedDialogue.setDialogueName(dialogueDefinition.getDialogueName());
 		loggedDialogue.setLanguage(dialogueDescription.getLanguage());
 		LoggedDialogueStoreIO.createLoggedDialogue(loggedDialogue);
@@ -207,7 +209,8 @@ public class DialogueExecutor {
 					(WoolNodePointerExternal)nodePointer;
 			String dialogueId = externalNodePointer.getDialogueId();
 			String nodeId = externalNodePointer.getNodeId();
-			return userService.startDialogue(dialogueId, nodeId, language);
+			return userService.startDialogue(dialogueId, nodeId, language,
+					loggedDialogue.getSessionId());
 		}
 	}
 

--- a/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/UserService.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/UserService.java
@@ -182,13 +182,14 @@ public class UserService {
 	 * @param dialogueId the dialogue ID
 	 * @param nodeId a node ID or null
 	 * @param language an ISO language tag
+	 * @param sessionId an (optional) identifier that should be added to the logging of dialogues
+	 *                  for this started dialogue session (may be {@code null}).
 	 * @return the dialogue node result with the start node or specified node
 	 */
-	public ExecuteNodeResult startDialogue(String dialogueId, String nodeId,
-										   String language) throws DatabaseException,
-			IOException, WoolException {
-		logger.info("User '" + woolUser.getId() + "' is starting dialogue '" +
-				dialogueId + "'");
+	public ExecuteNodeResult startDialogue(String dialogueId, String nodeId, String language,
+										   String sessionId)
+			throws DatabaseException, IOException, WoolException {
+		logger.info("User '" + woolUser.getId() + "' is starting dialogue '" + dialogueId + "'");
 		WoolDialogueDescription dialogueDescription =
 				getDialogueDescriptionFromId(dialogueId, language);
 		if (dialogueDescription == null) {
@@ -196,8 +197,7 @@ public class UserService {
 					"Dialogue not found: " + dialogueId);
 		}
 		WoolDialogue dialogue = getDialogueDefinition(dialogueDescription);
-		return dialogueExecutor.startDialogue(dialogueDescription,
-				dialogue, nodeId);
+		return dialogueExecutor.startDialogue(dialogueDescription, dialogue, nodeId, sessionId);
 	}
 
 	/**

--- a/java/WoolWebService/src/main/java/eu/woolplatform/web/service/storage/LoggedDialogue.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/web/service/storage/LoggedDialogue.java
@@ -19,6 +19,7 @@
 
 package eu.woolplatform.web.service.storage;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import eu.woolplatform.wool.model.WoolLoggedDialogue;
 import eu.woolplatform.wool.model.WoolLoggedInteraction;
@@ -32,6 +33,7 @@ import java.util.List;
 public class LoggedDialogue implements WoolLoggedDialogue {
 
 	private String id;
+	private String sessionId;
 	private String user;
 	private String localTime;
 	private long utcTime;
@@ -49,15 +51,18 @@ public class LoggedDialogue implements WoolLoggedDialogue {
 	 * Constructs a new instance at the specified time. It should define the
 	 * local time and location-based time zone (not an offset).
 	 *
-	 * @param user the user ID
+	 * @param user the identifier of the user for which the dialogue is being logged.
 	 * @param dialogueStartTime the time that this dialogue started in the time zone of the user.
+	 * @param sessionId an optional externally provided id to be added to the logs (or
+	 *                    {@code null}).
 	 */
-	public LoggedDialogue(String user, ZonedDateTime dialogueStartTime) {
+	public LoggedDialogue(String user, ZonedDateTime dialogueStartTime, String sessionId) {
 		this.user = user;
 		this.utcTime = dialogueStartTime.toInstant().toEpochMilli();
 		this.timezone = dialogueStartTime.getZone().toString();
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
 		this.localTime = dialogueStartTime.format(formatter);
+		this.sessionId = sessionId;
 	}
 
 	@Override
@@ -68,6 +73,23 @@ public class LoggedDialogue implements WoolLoggedDialogue {
 	@Override
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	/**
+	 * Returns the optional custom logging identifier, or {@code null} if none is set.
+	 * @return the optional custom logging identifier, or {@code null} if none is set.
+	 */
+	public String getSessionId() {
+		return sessionId;
+	}
+
+	/**
+	 * Sets an optional custom logging identifier that may be used to cross-reference WOOL Web
+	 * Service dialogue logs for a session with logs from an external system.
+	 * @param sessionId an optional custom logging identifier.
+	 */
+	public void setSessionId(String sessionId) {
+		this.sessionId = sessionId;
 	}
 
 	@Override
@@ -165,6 +187,7 @@ public class LoggedDialogue implements WoolLoggedDialogue {
 	 * {@link LoggedDialogue}.
 	 * @return the timestamp of the latest step in this {@link LoggedDialogue}.
 	 */
+	@JsonIgnore
 	public long getLatestInteractionTimestamp() {
 		if(interactionList.size() == 0) return this.getUtcTime();
 		else {


### PR DESCRIPTION
A 'sessionId' parameter can now optionally be added when starting a dialogue in the WOOL Web Service. This sessionId is attached to the dialogue logs for each interaction "in this session" (a session ends when a dialogue is finished, or when a new dialogue is started for this user).