### PR TITLE
WWS: Added /log/ end-points

### DIFF
--- a/java/WoolWebService/src/main/java/eu/woolplatform/web/service/controller/DialogueController.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/web/service/controller/DialogueController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 WOOL Foundation - Licensed under the MIT License:
+ * Copyright 2019-2023 WOOL Foundation - Licensed under the MIT License:
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -168,7 +168,8 @@ public class DialogueController {
 			String timeZone, String sessionId)
 			throws HttpException, IOException, DatabaseException {
 		ZoneId timeZoneId = ControllerFunctions.parseTimeZone(timeZone);
-		UserService userService = application.getApplicationManager().getActiveUserService(woolUserId);
+		UserService userService = application.getApplicationManager()
+				.getActiveUserService(woolUserId);
 		userService.getWoolUser().setTimeZone(timeZoneId);
 
 		// If no sessionId was provided, generate a unique one now
@@ -183,12 +184,13 @@ public class DialogueController {
 			if(userService.existsSessionId(sessionId)) {
 				throw new BadRequestException("The provided sessionId is already in use. When " +
 					"starting a new dialogue session with a predefined sessionId, this " +
-					"identifier has to be unique for this user ('"+woolUserId+"'.");
+					"identifier has to be unique for this user ('"+woolUserId+"').");
 			}
 		}
 
 		try {
-			ExecuteNodeResult node = userService.startDialogueSession(dialogueName, null, language, sessionId, System.currentTimeMillis());
+			ExecuteNodeResult node = userService.startDialogueSession(
+					dialogueName, null, language, sessionId, System.currentTimeMillis());
 			return DialogueMessageFactory.generateDialogueMessage(node);
 		} catch (WoolException e) {
 			throw ControllerFunctions.createHttpException(e);
@@ -394,7 +396,8 @@ public class DialogueController {
 					version, request, response, woolUserId, application);
 		} else {
 			return QueryRunner.runQuery(
-					(protocolVersion, user) -> doContinueDialogue(woolUserId, dialogueName, timeZone),
+					(protocolVersion, user) ->
+							doContinueDialogue(woolUserId, dialogueName, timeZone),
 					version, request, response, woolUserId, application);
 		}
 	}
@@ -419,7 +422,8 @@ public class DialogueController {
 
 		// Update/set the WOOL User's timezone to the given value
 		ZoneId timeZoneId = ControllerFunctions.parseTimeZone(timeZone);
-		UserService userService = application.getApplicationManager().getActiveUserService(woolUserId);
+		UserService userService = application.getApplicationManager()
+				.getActiveUserService(woolUserId);
 		userService.getWoolUser().setTimeZone(timeZoneId);
 
 		// Determine the event timestamp
@@ -494,7 +498,8 @@ public class DialogueController {
 		logger.info(logInfo);
 
 		if(woolUserId == null || woolUserId.equals("")) {
-			QueryRunner.runQuery((protocolVersion, user) -> doCancelDialogue(user, loggedDialogueId),
+			QueryRunner.runQuery((protocolVersion, user) -> doCancelDialogue(user,
+							loggedDialogueId),
 					version, request, response, woolUserId, application);
 		} else {
 			QueryRunner.runQuery((protocolVersion, user) -> doCancelDialogue(woolUserId,

--- a/java/WoolWebService/src/main/java/eu/woolplatform/web/service/controller/LogController.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/web/service/controller/LogController.java
@@ -80,7 +80,7 @@ public class LogController {
 			String sessionId,
 
 			@Parameter(description = "The user for which to check the session id (if left empty" +
-					"it is assumed to be the currently logged in user.")
+					" it is assumed to be the currently logged in user.")
 			@RequestParam(value="woolUserId", required = false)
 			String woolUserId) throws Exception {
 

--- a/java/WoolWebService/src/main/java/eu/woolplatform/web/service/controller/LogController.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/web/service/controller/LogController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 WOOL Foundation - Licensed under the MIT License:
+ * Copyright 2019-2023 WOOL Foundation - Licensed under the MIT License:
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -23,6 +23,7 @@ import eu.woolplatform.web.service.Application;
 import eu.woolplatform.web.service.ProtocolVersion;
 import eu.woolplatform.web.service.QueryRunner;
 import eu.woolplatform.web.service.execution.UserService;
+import eu.woolplatform.web.service.storage.LoggedDialogue;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -34,6 +35,9 @@ import nl.rrd.utils.exception.DatabaseException;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
  * Controller for the /log/... end-points of the WOOL Web Service. These end-points provide external
@@ -54,9 +58,63 @@ public class LogController {
 
 	private final Logger logger = AppComponents.getLogger(getClass().getSimpleName());
 
-	// ------------------------------------------------------ //
+	// --------------------------------------------------- //
+	// ---------- END-POINT: "/log/get-session" ---------- //
+	// --------------------------------------------------- //
+
+	@Operation(
+		summary = "Retrieve all known logging information for a given session",
+		description = "This method will retrieve all know logging information associated with " +
+				"the given sessionId")
+	@RequestMapping(value="/get-session", method= RequestMethod.GET)
+	public List<LoggedDialogue> getSession(
+			HttpServletRequest request,
+			HttpServletResponse response,
+
+			@Parameter(hidden = true, description = "API Version to use, e.g. '1'")
+			@PathVariable(value = "version")
+			String version,
+
+			@Parameter(description = "Session ID for which to check its existence.")
+			@RequestParam(value="sessionId")
+			String sessionId,
+
+			@Parameter(description = "The user for which to check the session id (if left empty" +
+					" it is assumed to be the currently logged in user.")
+			@RequestParam(value="woolUserId", required = false)
+			String woolUserId) throws Exception {
+
+		// If no versionName is provided, or versionName is empty, assume the latest version
+		if (version == null || version.equals("")) {
+			version = ProtocolVersion.getLatestVersion().versionName();
+		}
+
+		// Log this call to the service log
+		String logInfo = "GET /v" + version + "/log/get-session?sessionId=" + sessionId;
+		if(woolUserId != null && !woolUserId.equals("")) logInfo += "&woolUserId=" + woolUserId;
+		logger.info(logInfo);
+
+		if(woolUserId == null || woolUserId.equals("")) {
+			return QueryRunner.runQuery(
+					(protocolVersion, user) -> doGetSession(user, sessionId),
+					version, request, response, woolUserId, application);
+		} else {
+			return QueryRunner.runQuery(
+					(protocolVersion, user) -> doGetSession(woolUserId, sessionId),
+					version, request, response, woolUserId, application);
+		}
+	}
+
+	private List<LoggedDialogue> doGetSession(String woolUserId, String sessionId)
+			throws DatabaseException, IOException {
+		UserService userService =
+				application.getApplicationManager().getActiveUserService(woolUserId);
+		return userService.getDialogueSessionLog(sessionId);
+	}
+
+	// ------------------------------------------------- //
 	// ---------- END-POINT: "/log/verify-id" ---------- //
-	// ------------------------------------------------------ //
+	// ------------------------------------------------- //
 
 	@Operation(
 		summary = "Verify whether a dialogue session identifier is already in use for a given " +
@@ -107,8 +165,8 @@ public class LogController {
 	}
 
 	private Boolean doVerifyId(String woolUserId, String sessionId) throws DatabaseException {
-		// TODO: Test this method.
-		UserService userService = application.getApplicationManager().getActiveUserService(woolUserId);
+		UserService userService =
+				application.getApplicationManager().getActiveUserService(woolUserId);
 		return userService.existsSessionId(sessionId);
 	}
 

--- a/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/UserService.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/UserService.java
@@ -542,4 +542,8 @@ public class UserService {
 	public boolean existsSessionId(String sessionId) throws DatabaseException {
 		return loggedDialogueStore.existsSessionId(sessionId);
 	}
+
+	public List<LoggedDialogue> getDialogueSessionLog(String sessionId) throws IOException, DatabaseException {
+		return loggedDialogueStore.readSession(sessionId);
+	}
 }

--- a/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/UserService.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/web/service/execution/UserService.java
@@ -39,6 +39,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -94,7 +95,7 @@ public class UserService {
 		Configuration config = AppComponents.get(Configuration.class);
 		WoolVariableStoreStorageHandler storageHandler =
 				new WoolVariableStoreJSONStorageHandler(config.getDataDir() +
-						"/variables");
+						File.separator + config.getDirectoryNameVariables());
 		try {
 			this.variableStore = storageHandler.read(woolUser);
 		} catch (ParseException ex) {
@@ -538,9 +539,7 @@ public class UserService {
 	 * @param sessionId the sessionId {@link String} for which to check.
 	 * @return {@code true} if the sessionId is already in use, false otherwise.
 	 */
-	public boolean existsSessionId(String sessionId) {
-		//TODO: Implement.
-
-		return false;
+	public boolean existsSessionId(String sessionId) throws DatabaseException {
+		return loggedDialogueStore.existsSessionId(sessionId);
 	}
 }

--- a/java/WoolWebService/src/main/java/eu/woolplatform/web/service/storage/AzureDataLakeStore.java
+++ b/java/WoolWebService/src/main/java/eu/woolplatform/web/service/storage/AzureDataLakeStore.java
@@ -137,30 +137,35 @@ public class AzureDataLakeStore {
 	 * @throws IOException in case of an error writing to the local files.
 	 */
 	public void populateLocalDialogueLogs(String woolUserId) throws IOException {
+		logger.info("Populating local dialogue log folder for user '" + woolUserId + "'.");
 		DataLakeDirectoryClient directoryClient =
 				dataLakeFileSystemClient.getDirectoryClient(
 						config.getDirectoryNameDialogues() + "/" + woolUserId);
 
-		PagedIterable<PathItem> pathItems = directoryClient.listPaths();
+		// If there is a directory for the given woolUser
+		if (directoryClient.exists()) {
 
-		for (PathItem pathItem : pathItems) {
-			// item.getName() returns e.g. "dialogues/user-name/{fileName}.json"
-			Path path = Paths.get(config.getDataDir() + File.separator + pathItem.getName());
-			String fileName = path.getFileName().toString();
+			PagedIterable<PathItem> pathItems = directoryClient.listPaths();
 
-			logger.info("Found file on Azure Data Lake for user '" + woolUserId
-					+ "': " + pathItem.getName() + " (file name: '" + fileName + "').");
+			for (PathItem pathItem : pathItems) {
+				// item.getName() returns e.g. "dialogues/user-name/{fileName}.json"
+				Path path = Paths.get(config.getDataDir() + File.separator + pathItem.getName());
+				String fileName = path.getFileName().toString();
 
-			DataLakeFileClient fileClient =
-					dataLakeFileSystemClient.getFileClient(pathItem.getName());
+				logger.info("Found file on Azure Data Lake for user '" + woolUserId
+						+ "': " + pathItem.getName() + " (file name: '" + fileName + "').");
 
-			File localFile = new File(config.getDataDir() + File.separator +
-					config.getDirectoryNameDialogues() + File.separator +
-					woolUserId + File.separator + fileName);
+				DataLakeFileClient fileClient =
+						dataLakeFileSystemClient.getFileClient(pathItem.getName());
 
-			OutputStream targetStream = new FileOutputStream(localFile);
-			fileClient.read(targetStream);
-			targetStream.close();
+				File localFile = new File(config.getDataDir() + File.separator +
+						config.getDirectoryNameDialogues() + File.separator +
+						woolUserId + File.separator + fileName);
+
+				OutputStream targetStream = new FileOutputStream(localFile);
+				fileClient.read(targetStream);
+				targetStream.close();
+			}
 		}
 	}
 


### PR DESCRIPTION
The WOOL Web Service now offers two additional end-points that can provide log information:

- /log/verify-id can be used to check if a given sessionId is already in use for a given user.
- /log/get-session can be used to retrieve a list of LoggedDialogue objects belonging to the given {user,sessionId}-pair.